### PR TITLE
Patch to pull ClientId from environment instead of being hardcoded.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -30,7 +30,7 @@ builder.Services.AddAuthentication(options =>
 })
 .AddDiscord(options =>
 {
-    options.ClientId = "1112107024415735918";
+    options.ClientId = Environment.GetEnvironmentVariable("ClientId")!;
     options.ClientSecret = Environment.GetEnvironmentVariable("ClientSecret")!;
     options.Scope.Add("identify");
     options.Scope.Add("guilds");


### PR DESCRIPTION
This is not a security issue as ClientIds are not priviledged, rather a fix to standardize builds in test and prod environments.